### PR TITLE
Align sqlc interfaces with pgx stubs

### DIFF
--- a/server/internal/db/sqlc/assets.sql.go
+++ b/server/internal/db/sqlc/assets.sql.go
@@ -40,7 +40,7 @@ type InsertAssetParams struct {
 
 // sql 4c2a1a9e-1b77-4b8e-a1d2-9a7b2c3d4e5f
 func (q *Queries) InsertAsset(ctx context.Context, arg InsertAssetParams) (Asset, error) {
-	row := q.db.QueryRowContext(ctx, insertAsset,
+	row := q.db.QueryRow(ctx, insertAsset,
 		arg.UserID,
 		arg.Kind,
 		arg.RequestID,
@@ -99,7 +99,7 @@ type ListAssetsByUserRow struct {
 
 // sql 9a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
 func (q *Queries) ListAssetsByUser(ctx context.Context, arg ListAssetsByUserParams) ([]ListAssetsByUserRow, error) {
-	rows, err := q.db.QueryContext(ctx, listAssetsByUser, arg.UserID, arg.Column2)
+	rows, err := q.db.Query(ctx, listAssetsByUser, arg.UserID, arg.Column2)
 	if err != nil {
 		return nil, err
 	}
@@ -119,9 +119,6 @@ func (q *Queries) ListAssetsByUser(ctx context.Context, arg ListAssetsByUserPara
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/server/internal/db/sqlc/db.go
+++ b/server/internal/db/sqlc/db.go
@@ -6,14 +6,15 @@ package db
 
 import (
 	"context"
-	"database/sql"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
-	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 func New(db DBTX) *Queries {
@@ -24,7 +25,7 @@ type Queries struct {
 	db DBTX
 }
 
-func (q *Queries) WithTx(tx *sql.Tx) *Queries {
+func (q *Queries) WithTx(tx DBTX) *Queries {
 	return &Queries{
 		db: tx,
 	}

--- a/server/internal/db/sqlc/external_accounts.sql.go
+++ b/server/internal/db/sqlc/external_accounts.sql.go
@@ -30,7 +30,7 @@ type GetGoogleAccountByUserRow struct {
 
 // sql 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 func (q *Queries) GetGoogleAccountByUser(ctx context.Context, userID uuid.UUID) (GetGoogleAccountByUserRow, error) {
-	row := q.db.QueryRowContext(ctx, getGoogleAccountByUser, userID)
+	row := q.db.QueryRow(ctx, getGoogleAccountByUser, userID)
 	var i GetGoogleAccountByUserRow
 	err := row.Scan(
 		&i.ID,

--- a/server/internal/db/sqlc/generation_requests.sql.go
+++ b/server/internal/db/sqlc/generation_requests.sql.go
@@ -41,7 +41,7 @@ type ClaimNextQueuedJobRow struct {
 
 // sql 8c01c6e6-1f8e-4f61-9e2d-6040d7cf24af
 func (q *Queries) ClaimNextQueuedJob(ctx context.Context) (ClaimNextQueuedJobRow, error) {
-	row := q.db.QueryRowContext(ctx, claimNextQueuedJob)
+	row := q.db.QueryRow(ctx, claimNextQueuedJob)
 	var i ClaimNextQueuedJobRow
 	err := row.Scan(
 		&i.ID,
@@ -76,7 +76,7 @@ type EnqueueGenerationParams struct {
 
 // sql 6e7e8d2a-8d3f-4a1b-9a55-44f6c6f6f2f1
 func (q *Queries) EnqueueGeneration(ctx context.Context, arg EnqueueGenerationParams) (GenerationRequest, error) {
-	row := q.db.QueryRowContext(ctx, enqueueGeneration,
+	row := q.db.QueryRow(ctx, enqueueGeneration,
 		arg.UserID,
 		arg.TaskType,
 		arg.Provider,
@@ -130,7 +130,7 @@ type GetRequestStatusRow struct {
 
 // sql 2fa8b4d9-7c2f-4b90-b2a3-1d6f5b2c2b9a
 func (q *Queries) GetRequestStatus(ctx context.Context, id uuid.UUID) (GetRequestStatusRow, error) {
-	row := q.db.QueryRowContext(ctx, getRequestStatus, id)
+	row := q.db.QueryRow(ctx, getRequestStatus, id)
 	var i GetRequestStatusRow
 	err := row.Scan(
 		&i.ID,

--- a/server/internal/db/sqlc/metrics.sql.go
+++ b/server/internal/db/sqlc/metrics.sql.go
@@ -28,7 +28,7 @@ type GetDashboard24hRow struct {
 
 // sql 5d1b23a2-1d77-4df1-9c3a-9a1b2c3d4e5f
 func (q *Queries) GetDashboard24h(ctx context.Context) (GetDashboard24hRow, error) {
-	row := q.db.QueryRowContext(ctx, getDashboard24h)
+	row := q.db.QueryRow(ctx, getDashboard24h)
 	var i GetDashboard24hRow
 	err := row.Scan(
 		&i.ImageGenerated,

--- a/server/internal/stubs/pgx/pgconn/pgconn.go
+++ b/server/internal/stubs/pgx/pgconn/pgconn.go
@@ -1,0 +1,5 @@
+package pgconn
+
+type CommandTag struct{}
+
+func (c CommandTag) RowsAffected() int64 { return 0 }

--- a/server/internal/stubs/pgx/pgxpool/pgxpool.go
+++ b/server/internal/stubs/pgx/pgxpool/pgxpool.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // Config is a reduced configuration model compatible with the real pgxpool.
@@ -57,6 +58,6 @@ func (p *Pool) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
 }
 
 // Exec returns an empty command tag and a nil error to mimic successful execution.
-func (p *Pool) Exec(_ context.Context, _ string, _ ...any) (pgx.CommandTag, error) {
-	return pgx.CommandTag{}, nil
+func (p *Pool) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
 }


### PR DESCRIPTION
## Summary
- allow sqlc query helpers to wrap any DBTX implementation for transactions
- update the pgxpool stub Exec signature to return pgconn.CommandTag so it satisfies the DBTX contract

## Testing
- go test ./... *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68de65e02c44833391e4e6c7c2db5051