### PR TITLE
Fix Makefile recipe indentation

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -5,38 +5,38 @@ MIGRATION_DIR := db/migrations
 .PHONY: run worker migrate fmt vet lint test sqllint verify
 
 run:
-@set -a; \
-. ./.env 2>/dev/null || true; \
-set +a; \
-$(GO) run ./cmd/api
+	@set -a; \
+	. ./.env 2>/dev/null || true; \
+	set +a; \
+	$(GO) run ./cmd/api
 
 worker:
-@set -a; \
-. ./.env 2>/dev/null || true; \
-set +a; \
-$(GO) run ./cmd/worker
+	@set -a; \
+	. ./.env 2>/dev/null || true; \
+	set +a; \
+	$(GO) run ./cmd/worker
 
 migrate:
-@if [ -z "$$DATABASE_URL" ]; then \
-echo "DATABASE_URL is required"; \
-exit 1; \
-fi
-$(GOOSE) -dir $(MIGRATION_DIR) postgres "$$DATABASE_URL" up
+	@if [ -z "$$DATABASE_URL" ]; then \
+	echo "DATABASE_URL is required"; \
+	exit 1; \
+	fi
+	$(GOOSE) -dir $(MIGRATION_DIR) postgres "$$DATABASE_URL" up
 
 fmt:
-$(GO) fmt ./...
+	$(GO) fmt ./...
 
 vet:
-$(GO) vet ./...
+	$(GO) vet ./...
 
 lint:
-@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint is required"; exit 1; }
-golangci-lint run
+	@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint is required"; exit 1; }
+	golangci-lint run
 
 test:
-$(GO) test ./...
+	$(GO) test ./...
 
 sqllint:
-$(GO) run ./internal/tools/sqllint
+	$(GO) run ./internal/tools/sqllint
 
 verify: fmt vet lint sqllint test


### PR DESCRIPTION
## Summary
- replace recipe command indentation in the Makefile with tabs so GNU Make accepts the targets

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68de758f85d4833389c3c64590b04dc7