### PR TITLE
Add goose statement guards around function migrations

### DIFF
--- a/server/db/migrations/0004_properties_and_functions.sql
+++ b/server/db/migrations/0004_properties_and_functions.sql
@@ -59,6 +59,7 @@ CREATE INDEX IF NOT EXISTS ix_usage_events_request_id ON usage_events(request_id
 CREATE INDEX IF NOT EXISTS ix_usage_events_user_id ON usage_events(user_id);
 CREATE INDEX IF NOT EXISTS ix_donations_created_at ON donations(created_at DESC);
 
+-- +goose StatementBegin
 CREATE OR REPLACE FUNCTION fn_consume_quota(p_user_id uuid, p_used int)
 RETURNS TABLE (remaining int) AS $$
 DECLARE
@@ -91,7 +92,9 @@ BEGIN
     RETURN NEXT;
 END;
 $$ LANGUAGE plpgsql;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 CREATE OR REPLACE FUNCTION fn_insert_job_and_usage(
     p_user_id uuid,
     p_task text,
@@ -118,6 +121,7 @@ BEGIN
     RETURN NEXT;
 END;
 $$ LANGUAGE plpgsql;
+-- +goose StatementEnd
 
 CREATE OR REPLACE VIEW vw_stats_summary AS
 WITH totals AS (


### PR DESCRIPTION
## Summary
- wrap the quota and job helper functions in goose StatementBegin/StatementEnd markers to keep semicolons inside the body

## Testing
- go test ./... *(fails: interrupted due to long execution time)*

------
https://chatgpt.com/codex/tasks/task_e_68df61a794e48333b1122d0cdfe4ca02