### PR TITLE
Handle video generation asynchronously in worker

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -38,7 +38,7 @@ curl -i -X POST http://localhost:8080/v1/auth/google/verify \
 # Current user
 curl -i -H "Authorization: Bearer <JWT>" http://localhost:8080/v1/me
 
-# Generate images
+# Generate images (async via worker)
 curl -i -X POST http://localhost:8080/v1/images/generate \
   -H "Authorization: Bearer <JWT>" -H 'Content-Type: application/json' \
   -d '{
@@ -65,6 +65,11 @@ curl -i -H "Authorization: Bearer <JWT>" http://localhost:8080/v1/images/<JOB_ID
 
 # Zip assets
 curl -i -X POST -H "Authorization: Bearer <JWT>" http://localhost:8080/v1/images/<JOB_ID>/zip
+
+# Generate videos (async via worker)
+curl -i -X POST -H "Authorization: Bearer <JWT>" http://localhost:8080/v1/videos/generate \
+  -H 'Content-Type: application/json' \
+  -d '{"provider":"veo2","prompt":"Hero shot ramen"}'
 
 # Ideas
 curl -i -X POST -H "Authorization: Bearer <JWT>" http://localhost:8080/v1/ideas/from-image \

--- a/server/README_Codex.md
+++ b/server/README_Codex.md
@@ -62,7 +62,7 @@ curl -i http://localhost:1919/v1/healthz
   > Catatan: ada endpoint **enhance**. Standarisasi final disarankan: `POST /v1/images/enhance`.
 * **Videos**:
 
-  * `POST /v1/videos/generate` *(saat ini sinkron stub; **target**: async via worker)*
+* `POST /v1/videos/generate` *(enqueue → diproses worker async)*
   * `GET  /v1/videos/{job_id}/status|assets`
 * **Ideas**: `POST /v1/ideas/from-image` → validasi & kembalikan 2 ide dummy.
 * **Assets**:
@@ -73,8 +73,8 @@ curl -i http://localhost:1919/v1/healthz
 ### Infrastruktur yang sudah ada
 
 * **Kuota harian**: di `users.properties` + **`fn_consume_quota`** (atomik saat enqueue).
-* **Worker**: ambil job `queued` (`FOR UPDATE SKIP LOCKED`) → set `running` → panggil provider gambar **stub** → simpan aset → set `succeeded/failed`.
-* **Video**: saat ini **sync** (di handler) → **TODO** pindah ke **worker**.
+* **Worker**: ambil job `queued` (`FOR UPDATE SKIP LOCKED`) → set `running` → panggil provider gambar/video **stub** → simpan aset → set `succeeded/failed`.
+* **Video**: sekarang ikut pipeline async di worker (enqueue → worker → assets & status).
 * **sqllint**: build-blocking; inline SQL wajib ber-UUID.
 * **Makefile**: target `run`, `worker`, `migrate`, `lint`, `verify`.
 
@@ -268,7 +268,7 @@ POST /images/{job_id}/zip
 
 POST /ideas/from-image
 
-POST /videos/generate              # target: async (enqueue) → worker
+POST /videos/generate              # async (enqueue) → worker
 GET  /videos/{job_id}/status
 GET  /videos/{job_id}/assets
 
@@ -280,7 +280,7 @@ POST /donations
 GET  /donations/testimonials
 ```
 
-> **Catatan:** Saat ini videos **sync** (stub), **TODO** pindah ke worker agar konsisten dengan images.
+> **Catatan:** Videos sekarang mengikuti pipeline async worker → status berubah `queued → running → succeeded/failed`.
 
 ---
 

--- a/server/cmd/worker/main.go
+++ b/server/cmd/worker/main.go
@@ -8,7 +8,10 @@ import (
 	"server/internal/domain/jsoncfg"
 	"server/internal/infra"
 	"server/internal/providers/image"
+	videoprovider "server/internal/providers/video"
 	"server/internal/sqlinline"
+
+	"github.com/rs/zerolog"
 )
 
 func main() {
@@ -26,9 +29,13 @@ func main() {
 	defer pool.Close()
 
 	runner := infra.NewSQLRunner(pool, logger)
-	providers := map[string]image.Generator{
+	imageProviders := map[string]image.Generator{
 		"gemini":     image.NewNanoBanana(),
 		"nanobanana": image.NewNanoBanana(),
+	}
+	videoProviders := map[string]videoprovider.Generator{
+		"veo2": videoprovider.NewVEO(),
+		"veo3": videoprovider.NewVEO(),
 	}
 
 	logger.Info().Msg("worker started")
@@ -38,46 +45,119 @@ func main() {
 			return
 		default:
 		}
-		var jobID, userID, provider string
+		var jobID, userID, taskType, provider string
 		var quantity int
 		var aspect string
 		var promptBytes []byte
 		row := runner.QueryRow(ctx, sqlinline.QWorkerClaimJob)
-		if err := row.Scan(&jobID, &userID, &provider, &quantity, &aspect, &promptBytes); err != nil {
+		if err := row.Scan(&jobID, &userID, &taskType, &provider, &quantity, &aspect, &promptBytes); err != nil {
 			time.Sleep(2 * time.Second)
 			continue
 		}
-		logger.Info().Msgf("worker: picked job %s", jobID)
-		var prompt jsoncfg.PromptJSON
-		_ = json.Unmarshal(promptBytes, &prompt)
-		generator, ok := providers[provider]
-		if !ok {
-			provider = "gemini"
-			generator = providers[provider]
-		}
-		assets, err := generator.Generate(ctx, image.GenerateRequest{
-			Prompt:       prompt.Title,
-			Quantity:     quantity,
-			AspectRatio:  aspect,
-			Provider:     provider,
-			RequestID:    jobID,
-			Locale:       prompt.Extras.Locale,
-			WatermarkTag: prompt.Watermark.Text,
-		})
-		status := "SUCCEEDED"
-		if err != nil {
-			status = "FAILED"
-			logger.Error().Err(err).Msgf("worker: generation failed for %s", jobID)
-		} else {
-			for _, asset := range assets {
-				_, execErr := runner.Exec(ctx, sqlinline.QInsertAsset, userID, "GENERATED", jobID, asset.URL, asset.Format, int64(1024*1024), asset.Width, asset.Height, aspect, jsoncfg.MustMarshal(map[string]any{"provider": provider}))
-				if execErr != nil {
-					logger.Error().Err(execErr).Msgf("worker: insert asset failed for %s", jobID)
-				}
-			}
+		logger.Info().Str("job_id", jobID).Str("task_type", taskType).Msg("worker: picked job")
+		status := "FAILED"
+		switch taskType {
+		case "IMAGE_GEN":
+			status = processImageJob(ctx, runner, imageProviders, logger, jobID, userID, provider, quantity, aspect, promptBytes)
+		case "VIDEO_GEN":
+			status = processVideoJob(ctx, runner, videoProviders, logger, jobID, userID, provider, aspect, promptBytes)
+		default:
+			logger.Error().Str("job_id", jobID).Str("task_type", taskType).Msg("worker: unsupported job type")
 		}
 		if _, err := runner.Exec(ctx, sqlinline.QUpdateJobStatus, jobID, status); err != nil {
 			logger.Error().Err(err).Msgf("worker: update status failed for %s", jobID)
 		}
 	}
+}
+
+func processImageJob(
+	ctx context.Context,
+	runner *infra.SQLRunner,
+	providers map[string]image.Generator,
+	logger zerolog.Logger,
+	jobID, userID, provider string,
+	quantity int,
+	aspect string,
+	promptBytes []byte,
+) string {
+	var prompt jsoncfg.PromptJSON
+	_ = json.Unmarshal(promptBytes, &prompt)
+	generator, ok := providers[provider]
+	if !ok {
+		provider = "gemini"
+		generator = providers[provider]
+	}
+	assets, err := generator.Generate(ctx, image.GenerateRequest{
+		Prompt:       prompt.Title,
+		Quantity:     quantity,
+		AspectRatio:  aspect,
+		Provider:     provider,
+		RequestID:    jobID,
+		Locale:       prompt.Extras.Locale,
+		WatermarkTag: prompt.Watermark.Text,
+	})
+	if err != nil {
+		logger.Error().Err(err).Str("job_id", jobID).Msg("worker: image generation failed")
+		return "FAILED"
+	}
+	for _, asset := range assets {
+		if _, execErr := runner.Exec(ctx, sqlinline.QInsertAsset, userID, "GENERATED", jobID, asset.URL, asset.Format, int64(1024*1024), asset.Width, asset.Height, aspect, jsoncfg.MustMarshal(map[string]any{"provider": provider})); execErr != nil {
+			logger.Error().Err(execErr).Str("job_id", jobID).Msg("worker: insert image asset failed")
+		}
+	}
+	return "SUCCEEDED"
+}
+
+func processVideoJob(
+	ctx context.Context,
+	runner *infra.SQLRunner,
+	providers map[string]videoprovider.Generator,
+	logger zerolog.Logger,
+	jobID, userID, provider, aspect string,
+	promptBytes []byte,
+) string {
+	payload := map[string]any{}
+	_ = json.Unmarshal(promptBytes, &payload)
+	promptText := extractPromptText(payload)
+	locale := ""
+	if v, ok := payload["locale"].(string); ok {
+		locale = v
+	}
+	generator, ok := providers[provider]
+	if !ok {
+		provider = "veo2"
+		generator = providers[provider]
+	}
+	asset, err := generator.Generate(ctx, videoprovider.GenerateRequest{
+		Prompt:    promptText,
+		Provider:  provider,
+		RequestID: jobID,
+		Locale:    locale,
+	})
+	if err != nil {
+		logger.Error().Err(err).Str("job_id", jobID).Msg("worker: video generation failed")
+		return "FAILED"
+	}
+	if _, execErr := runner.Exec(ctx, sqlinline.QInsertAsset, userID, "GENERATED", jobID, asset.URL, asset.Format, int64(5*1024*1024), 1920, 1080, aspect, jsoncfg.MustMarshal(map[string]any{"provider": provider, "length": asset.Length})); execErr != nil {
+		logger.Error().Err(execErr).Str("job_id", jobID).Msg("worker: insert video asset failed")
+	}
+	return "SUCCEEDED"
+}
+
+func extractPromptText(payload map[string]any) string {
+	if payload == nil {
+		return ""
+	}
+	if text, ok := payload["prompt"].(string); ok {
+		return text
+	}
+	if nested, ok := payload["prompt"].(map[string]any); ok {
+		if text, ok := nested["text"].(string); ok {
+			return text
+		}
+		if title, ok := nested["title"].(string); ok {
+			return title
+		}
+	}
+	return ""
 }

--- a/server/internal/infra/google/jwks.go
+++ b/server/internal/infra/google/jwks.go
@@ -105,7 +105,9 @@ func (v *Verifier) refresh(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	var set jwks
 	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
 		return err
@@ -142,7 +144,9 @@ func (v *Verifier) fetchConfig(ctx context.Context) (*struct {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	var cfg struct {
 		JWKSURI string `json:"jwks_uri"`
 	}

--- a/server/internal/sqlinline/videos.go
+++ b/server/internal/sqlinline/videos.go
@@ -7,11 +7,14 @@ with input as (
     $2::jsonb as prompt_json,
     $3::text as provider
 ),
+quota as (
+  select remaining from fn_consume_quota((select user_id from input), 1)
+),
 job as (
   select job_id from fn_insert_job_and_usage(
     (select user_id from input),
     'VIDEO_GEN',
-    'RUNNING',
+    'QUEUED',
     (select prompt_json from input),
     1,
     '16:9',
@@ -19,5 +22,6 @@ job as (
     '{}'::jsonb
   )
 )
-select job_id from job;
+select job.job_id, quota.remaining
+from job, quota;
 `

--- a/server/internal/sqlinline/worker.go
+++ b/server/internal/sqlinline/worker.go
@@ -13,7 +13,7 @@ updated as (
     update generation_requests
     set status = 'RUNNING', updated_at = now()
     where id in (select id from next_job)
-    returning id, user_id, provider, quantity, aspect_ratio, prompt_json
+    returning id, user_id, task_type, provider, quantity, aspect_ratio, prompt_json
 )
 select * from updated;
 `


### PR DESCRIPTION
## Summary
- enqueue `/v1/videos/generate` requests with JSONB payloads and quota tracking before returning a queued job response
- extend the background worker to process both image and video jobs, persisting generated assets and metadata asynchronously
- refresh project docs to describe the async video pipeline and updated endpoints
- restore zerolog stub chaining so `logger.Info().Str(...).Msg(...)` works under go vet
- close JWKS HTTP responses with error-checked defers to satisfy errcheck

## Testing
- `make verify`

## Changed Files
- `server/internal/infra/google/jwks.go`
- `server/internal/stubs/zerolog/zerolog.go`

## Commands
```bash
go mod tidy
make migrate
make run
make worker
```

## Example curl
```bash
curl -i -H "Authorization: Bearer <JWT>" \
  -X POST http://localhost:1919/v1/videos/generate \
  -H 'Content-Type: application/json' \
  -d '{"provider":"veo2","prompt":{"title":"Hero shot ramen"}}'
```

## Notes
- Semua SQL inline wajib diawali komentar `--sql <UUIDv4>` agar lolos sqllint.
- Tambah SQL baru melalui konstanta di `internal/sqlinline/` dan gunakan `infra.SQLRunner` supaya `sql_uuid` ikut tercatat di log.
- Fitur baru sebaiknya dikonfigurasi lewat kolom `properties` JSONB + struct domain agar skema inti tetap stabil.


------
https://chatgpt.com/codex/tasks/task_e_68df6a07e0a88333af688747370c962d