### PR TITLE
Add static OpenAPI spec and documentation endpoints

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -27,6 +27,10 @@ make verify
 
 ## Key endpoints
 ```bash
+# API documentation
+curl -i http://localhost:8080/v1/openapi.json
+curl -i http://localhost:8080/v1/docs
+
 # Health
 curl -i http://localhost:8080/v1/healthz
 

--- a/server/README_Codex.md
+++ b/server/README_Codex.md
@@ -43,6 +43,8 @@ curl -i http://localhost:1919/v1/healthz
 ### Tanpa autentikasi
 
 * `GET  /v1/healthz` → health OK.
+* `GET  /v1/openapi.json` → spesifikasi OpenAPI statis.
+* `GET  /v1/docs` → Redoc menampilkan spesifikasi di atas.
 * `POST /v1/auth/google/verify` → verifikasi Google **ID token** (JWKS), **upsert user + external_account**, balas **JWT + profil**.
 * `GET  /v1/stats/summary` → agregasi statistik langsung dari DB (view/CTE).
 * `POST /v1/donations`, `GET /v1/donations/testimonials` → mencatat donasi & membaca testimoni via SQL.

--- a/server/internal/http/handlers/openapi.go
+++ b/server/internal/http/handlers/openapi.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed openapi.json
+var openAPISpec []byte
+
+const redocHTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>UMKM SaaS API Docs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      redoc {
+        display: block;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url="/v1/openapi.json"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.2.0/bundles/redoc.standalone.js"></script>
+  </body>
+</html>`
+
+func (a *App) OpenAPIJSON(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(openAPISpec)
+}
+
+func (a *App) OpenAPIDocs(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(redocHTML))
+}

--- a/server/internal/http/handlers/openapi.json
+++ b/server/internal/http/handlers/openapi.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "UMKM SaaS API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/healthz": {
+      "get": {
+        "summary": "Health check",
+        "description": "Returns service health information.",
+        "responses": {
+          "200": {
+            "description": "Service is healthy"
+          }
+        }
+      }
+    },
+    "/v1/stats/summary": {
+      "get": {
+        "summary": "Fetch API usage statistics",
+        "responses": {
+          "200": {
+            "description": "Aggregate statistics response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/internal/http/httpapi/router.go
+++ b/server/internal/http/httpapi/router.go
@@ -21,6 +21,8 @@ func NewRouter(app *handlers.App) http.Handler {
 
 	r.Route("/v1", func(r chi.Router) {
 		r.Get("/healthz", app.Health)
+		r.Get("/openapi.json", app.OpenAPIJSON)
+		r.Get("/docs", app.OpenAPIDocs)
 
 		r.Post("/auth/google/verify", app.AuthGoogleVerify)
 		r.With(middleware.AuthJWT(app.JWTSecret)).Get("/me", app.Me)


### PR DESCRIPTION
## Summary
- add HTTP handlers that serve the embedded OpenAPI spec and Redoc documentation
- register /v1/openapi.json and /v1/docs routes on the API router
- document the new documentation endpoints in the READMEs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df91dc2de4833393c319c227ad686d