### PR TITLE
Add GeoIP resolver to locale middleware

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v0.0.0
+	github.com/oschwald/geoip2-golang v1.11.0
 	github.com/rs/zerolog v1.33.0
 	golang.org/x/text v0.29.0
 )
@@ -19,3 +20,5 @@ replace github.com/rs/zerolog => ./internal/stubs/zerolog
 replace github.com/lib/pq => ./internal/stubs/libpq
 
 replace github.com/pressly/goose/v3 => ./internal/stubs/goose
+
+replace github.com/oschwald/geoip2-golang => ./internal/stubs/geoip2

--- a/server/internal/http/httpapi/router.go
+++ b/server/internal/http/httpapi/router.go
@@ -15,7 +15,12 @@ func NewRouter(app *handlers.App) http.Handler {
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger(app.Logger))
-	r.Use(middleware.I18N("en"))
+
+	var geoLookup middleware.CountryLookup
+	if app.GeoIPResolver != nil {
+		geoLookup = app.GeoIPResolver.CountryCode
+	}
+	r.Use(middleware.I18N("en", geoLookup))
 	r.Use(middleware.CORS([]string{"http://localhost:3000", "https://script.google.com"}))
 	r.Use(middleware.RateLimit(app.Config.RateLimitPerMin, time.Minute))
 

--- a/server/internal/infra/geoip/resolver.go
+++ b/server/internal/infra/geoip/resolver.go
@@ -1,0 +1,62 @@
+package geoip
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/oschwald/geoip2-golang"
+)
+
+// ErrUnavailable is returned when the resolver is not initialized.
+var ErrUnavailable = errors.New("geoip resolver unavailable")
+
+// CountryResolver resolves ISO country codes from IP addresses.
+type CountryResolver interface {
+	CountryCode(ip string) (string, error)
+}
+
+// Resolver provides country lookups backed by a MaxMind GeoIP2 database.
+type Resolver struct {
+	reader *geoip2.Reader
+}
+
+// NewResolver opens the GeoIP database at the given path. When the path is empty, nil is returned.
+func NewResolver(path string) (CountryResolver, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	reader, err := geoip2.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("geoip: open database: %w", err)
+	}
+	return &Resolver{reader: reader}, nil
+}
+
+// CountryCode returns the ISO country code for the provided IP.
+func (r *Resolver) CountryCode(ip string) (string, error) {
+	if r == nil || r.reader == nil {
+		return "", ErrUnavailable
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return "", fmt.Errorf("geoip: invalid ip %q", ip)
+	}
+	record, err := r.reader.Country(parsed)
+	if err != nil {
+		return "", fmt.Errorf("geoip: lookup country: %w", err)
+	}
+	if record == nil || record.Country.IsoCode == "" {
+		return "", nil
+	}
+	return record.Country.IsoCode, nil
+}
+
+// Close closes the underlying database reader.
+func (r *Resolver) Close() error {
+	if r == nil || r.reader == nil {
+		return nil
+	}
+	return r.reader.Close()
+}

--- a/server/internal/middleware/i18n_test.go
+++ b/server/internal/middleware/i18n_test.go
@@ -7,17 +7,26 @@ import (
 	"testing"
 )
 
+type assertError string
+
+func (e assertError) Error() string { return string(e) }
+
 func TestDetectLocale(t *testing.T) {
 	tests := []struct {
 		name     string
 		setup    func(r *http.Request)
 		fallback string
+		resolver CountryLookup
 		want     string
 	}{
 		{
 			name: "x-locale overrides",
 			setup: func(r *http.Request) {
 				r.Header.Set("X-Locale", "ID")
+			},
+			resolver: func(ip string) (string, error) {
+				t.Fatalf("resolver should not be called")
+				return "", nil
 			},
 			want: "id",
 		},
@@ -26,6 +35,10 @@ func TestDetectLocale(t *testing.T) {
 			setup: func(r *http.Request) {
 				r.Header.Set("Accept-Language", "en-US,en;q=0.9")
 			},
+			resolver: func(ip string) (string, error) {
+				t.Fatalf("resolver should not be called")
+				return "", nil
+			},
 			want: "en",
 		},
 		{
@@ -33,36 +46,56 @@ func TestDetectLocale(t *testing.T) {
 			setup: func(r *http.Request) {
 				r.Header.Set("Accept-Language", "id-ID,en;q=0.8")
 			},
-			want: "id",
-		},
-		{
-			name: "geoip fallback",
-			setup: func(r *http.Request) {
-				r.RemoteAddr = "103.21.77.15:1234"
+			resolver: func(ip string) (string, error) {
+				t.Fatalf("resolver should not be called")
+				return "", nil
 			},
 			want: "id",
 		},
 		{
-			name:     "configured fallback",
-			setup:    func(r *http.Request) {},
+			name: "geoip returns id",
+			resolver: func(ip string) (string, error) {
+				if ip != "203.0.113.4" {
+					t.Fatalf("unexpected ip: %s", ip)
+				}
+				return "ID", nil
+			},
+			want: "id",
+		},
+		{
+			name: "geoip returns non-id",
+			resolver: func(ip string) (string, error) {
+				return "US", nil
+			},
+			want: "en",
+		},
+		{
+			name: "geoip error falls back",
+			resolver: func(ip string) (string, error) {
+				return "", assertError("boom")
+			},
 			fallback: "id",
 			want:     "id",
 		},
 		{
-			name:  "default to en",
-			setup: func(r *http.Request) {},
-			want:  "en",
+			name:     "configured fallback",
+			fallback: "id",
+			want:     "id",
+		},
+		{
+			name: "default to en",
+			want: "en",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
-			req.RemoteAddr = "192.0.2.1:80"
+			req.RemoteAddr = "203.0.113.4:80"
 			if tc.setup != nil {
 				tc.setup(req)
 			}
-			got := detectLocale(req, tc.fallback)
+			got := detectLocale(req, tc.fallback, tc.resolver)
 			if got != tc.want {
 				t.Fatalf("detectLocale() = %q, want %q", got, tc.want)
 			}

--- a/server/internal/stubs/geoip2/geoip2.go
+++ b/server/internal/stubs/geoip2/geoip2.go
@@ -1,0 +1,31 @@
+package geoip2
+
+import (
+	"fmt"
+	"net"
+)
+
+// Reader is a stubbed GeoIP2 database reader used in tests.
+type Reader struct{}
+
+// Open returns an error to indicate the stub does not provide GeoIP lookups.
+func Open(path string) (*Reader, error) {
+	return nil, fmt.Errorf("geoip2 stub: no database support")
+}
+
+// Close implements the io.Closer interface.
+func (r *Reader) Close() error {
+	return nil
+}
+
+// Country is a stubbed response structure matching the real library.
+type Country struct {
+	Country struct {
+		IsoCode string
+	}
+}
+
+// Country always returns an error because the stub has no database support.
+func (r *Reader) Country(ip net.IP) (*Country, error) {
+	return nil, fmt.Errorf("geoip2 stub: no database support")
+}

--- a/server/internal/stubs/geoip2/go.mod
+++ b/server/internal/stubs/geoip2/go.mod
@@ -1,0 +1,3 @@
+module github.com/oschwald/geoip2-golang
+
+go 1.24.0

--- a/server/internal/stubs/zerolog/zerolog.go
+++ b/server/internal/stubs/zerolog/zerolog.go
@@ -93,6 +93,9 @@ func (l Logger) newEvent(level Level) *Event {
 // Info starts an info-level event.
 func (l Logger) Info() *Event { return l.newEvent(InfoLevel) }
 
+// Warn starts a warn-level event.
+func (l Logger) Warn() *Event { return l.newEvent(InfoLevel) }
+
 // Error starts an error-level event.
 func (l Logger) Error() *Event { return l.newEvent(InfoLevel) }
 


### PR DESCRIPTION
## Summary
- introduce a GeoIP resolver that loads the MaxMind database and expose a lookup helper for ISO country codes
- wire the resolver into the HTTP stack and extend the i18n middleware to fall back to GeoIP detection when headers are absent
- add focused middleware tests and a stub geoip2 module plus logger update to support the new workflow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dfbbebfa148333b525b33607fa04b6