### PR TITLE
Improve Google login robustness

### DIFF
--- a/server/internal/http/handlers/auth.go
+++ b/server/internal/http/handlers/auth.go
@@ -66,6 +66,11 @@ func (a *App) AuthGoogleVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	props, quotaDaily, quotaUsed := extractQuota(propsBytes)
+	if v, ok := props["preferred_locale"].(string); ok && v != "" {
+		locale = v
+	} else if v, ok := props["google_locale"].(string); ok && v != "" {
+		locale = v
+	}
 	token, err := middleware.SignJWT(a.JWTSecret, middleware.TokenClaims{
 		Sub:      userID,
 		Plan:     plan,

--- a/server/internal/infra/google/jwks_test.go
+++ b/server/internal/infra/google/jwks_test.go
@@ -1,0 +1,25 @@
+package google
+
+import "testing"
+
+func TestAudienceMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		aud      any
+		clientID string
+		want     bool
+	}{
+		{name: "string match", aud: "client", clientID: "client", want: true},
+		{name: "string mismatch", aud: "client", clientID: "other", want: false},
+		{name: "slice any match", aud: []any{"other", "client"}, clientID: "client", want: true},
+		{name: "slice any mismatch", aud: []any{"other", 1}, clientID: "client", want: false},
+		{name: "slice string match", aud: []string{"client", "alt"}, clientID: "client", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := audienceMatches(tc.aud, tc.clientID); got != tc.want {
+				t.Fatalf("audienceMatches(%v, %q) = %v, want %v", tc.aud, tc.clientID, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- accept array-based Google token audiences and reuse the stored preferred locale when issuing JWTs
- harden the Google user upsert query so it always returns the user row and refreshes metadata for both users and external accounts
- add unit coverage for the new audience matcher helper

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dfb6e777d083339d473acef0879cb3