### PR TITLE
Capture user login metadata

### DIFF
--- a/server/internal/middleware/i18n.go
+++ b/server/internal/middleware/i18n.go
@@ -32,7 +32,7 @@ func detectLocale(r *http.Request, fallback string, lookup CountryLookup) string
 		return v
 	}
 	if lookup != nil {
-		if ip := clientIP(r); ip != "" {
+		if ip := ClientIP(r); ip != "" {
 			if country, err := lookup(ip); err == nil {
 				if strings.EqualFold(country, "ID") {
 					return "id"
@@ -69,7 +69,11 @@ func normalizeLocale(locale string) string {
 	return "en"
 }
 
-func clientIP(r *http.Request) string {
+// ClientIP returns the best-effort client IP address for the request.
+func ClientIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
 	if xf := r.Header.Get("X-Forwarded-For"); xf != "" {
 		parts := strings.Split(xf, ",")
 		if len(parts) > 0 {


### PR DESCRIPTION
## Summary
- capture the client country when verifying Google sign-in and pass it into the user upsert so `last_ip_country`/`last_seen_at` are recorded
- expose `middleware.ClientIP` so handlers and middleware share the same IP extraction logic
- extend the Google user upsert SQL to persist country metadata without breaking existing JSONB property updates

## Files Changed
- server/internal/http/handlers/auth.go
- server/internal/middleware/i18n.go
- server/internal/sqlinline/users.go

## Testing
- go test ./internal/middleware -run TestI18N -count=1 -v *(hangs in this environment while fetching modules; cancelled)*

## How to Run
- go mod tidy
- make migrate
- make run
- make worker

## Example curl
```bash
curl -i -H "Authorization: Bearer <JWT>" http://localhost:1919/v1/me
```

## Notes
- sqllint still enforces `--sql <UUIDv4>` headers for every inline query; keep using JSONB `properties` for incremental metadata changes.


------
https://chatgpt.com/codex/tasks/task_e_68e0073dc5508333bf2774aa2a55968b