### PR TITLE
Integrate Gemini-driven prompt enhancer and usage logging

### DIFF
--- a/server/db/migrations/0005_usage_events_prompts.sql
+++ b/server/db/migrations/0005_usage_events_prompts.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE usage_events DROP CONSTRAINT IF EXISTS usage_events_event_type_check;
+ALTER TABLE usage_events
+    ADD CONSTRAINT usage_events_event_type_check
+    CHECK (event_type IN ('IMAGE_GEN','VIDEO_GEN','UPSCALE','PROMPT_ENHANCE','PROMPT_RANDOM','PROMPT_CLEAR'));
+
+-- +goose Down
+ALTER TABLE usage_events DROP CONSTRAINT IF EXISTS usage_events_event_type_check;
+ALTER TABLE usage_events
+    ADD CONSTRAINT usage_events_event_type_check
+    CHECK (event_type IN ('IMAGE_GEN','VIDEO_GEN','UPSCALE'));

--- a/server/internal/domain/jsoncfg/prompt_test.go
+++ b/server/internal/domain/jsoncfg/prompt_test.go
@@ -51,3 +51,36 @@ func TestPromptJSONNormalizeMinimumQuantity(t *testing.T) {
 		t.Fatalf("Quantity = %d, want %d", p.Quantity, DefaultPromptQuantity)
 	}
 }
+
+func TestPromptJSONValidate(t *testing.T) {
+	prompt := PromptJSON{
+		Version:      DefaultPromptVersion,
+		Title:        "Nasi Goreng Premium",
+		ProductType:  "food",
+		Style:        "elegan",
+		Background:   "marble",
+		Instructions: "Gunakan lighting lembut",
+		Watermark: WatermarkConfig{
+			Enabled:  true,
+			Text:     "Brand",
+			Position: "bottom-right",
+		},
+		AspectRatio: "1:1",
+		Quantity:    1,
+	}
+	if err := prompt.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+
+	prompt.AspectRatio = "2:1"
+	if err := prompt.Validate(); err == nil {
+		t.Fatalf("Validate() expected error for invalid aspect ratio")
+	}
+
+	prompt.AspectRatio = "1:1"
+	prompt.Watermark.Enabled = true
+	prompt.Watermark.Text = ""
+	if err := prompt.Validate(); err == nil {
+		t.Fatalf("Validate() expected error when watermark text missing")
+	}
+}

--- a/server/internal/http/handlers/prompts.go
+++ b/server/internal/http/handlers/prompts.go
@@ -9,6 +9,8 @@ import (
 	"server/internal/middleware"
 	"server/internal/providers/prompt"
 	"server/internal/sqlinline"
+
+	"github.com/google/uuid"
 )
 
 type promptEnhanceRequest struct {
@@ -33,32 +35,98 @@ func (a *App) PromptEnhance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	locale := middleware.LocaleFromContext(r.Context())
-	res, err := a.PromptEnhancer.Enhance(r.Context(), prompt.EnhanceRequest{
-		Title:       req.Prompt.Title,
-		ProductType: req.Prompt.ProductType,
-		Locale:      locale,
-	})
-	if err != nil {
+	req.Prompt.Normalize(locale)
+	if err := req.Prompt.Validate(); err != nil {
+		a.error(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	enhanceReq := prompt.EnhanceRequest{Prompt: req.Prompt, Locale: req.Prompt.Extras.Locale}
+	started := time.Now()
+	res, err := a.PromptEnhancer.Enhance(r.Context(), enhanceReq)
+	success := err == nil && res != nil
+	latency := int(time.Since(started).Milliseconds())
+	if latency < 0 {
+		latency = 0
+	}
+	if !success {
+		a.logUsageEvent(r, userID, "PROMPT_ENHANCE", false, latency, map[string]any{"error": "enhancer_failed"})
 		a.error(w, http.StatusInternalServerError, "internal", "enhancer failed")
 		return
 	}
 	enriched := req.Prompt
-	enriched.Extras.Locale = locale
-	ideas := []map[string]any{{
-		"title":       res.Title,
-		"description": res.Description,
-		"keywords":    res.Keywords,
-	}}
-	_, _ = a.SQL.Exec(r.Context(), sqlinline.QInsertUsageEvent, userID, nil, "PROMPT_ENHANCE", true, 0, jsoncfg.MustMarshal(map[string]any{"locale": locale}))
+	if res.Metadata != nil {
+		if v, ok := res.Metadata["locale"]; ok && v != "" {
+			enriched.Extras.Locale = v
+		}
+	}
+	ideas := make([]map[string]any, 0, len(res.Ideas))
+	for _, idea := range res.Ideas {
+		ideas = append(ideas, map[string]any{
+			"title":       idea.Title,
+			"description": idea.Description,
+			"keywords":    idea.Keywords,
+		})
+	}
+	if len(ideas) == 0 {
+		ideas = append(ideas, map[string]any{
+			"title":       res.Title,
+			"description": res.Description,
+			"keywords":    res.Keywords,
+		})
+	}
+	props := map[string]any{
+		"locale":   enriched.Extras.Locale,
+		"provider": res.Provider,
+	}
+	if len(res.Metadata) > 0 {
+		props["metadata"] = res.Metadata
+	}
+	a.logUsageEvent(r, userID, "PROMPT_ENHANCE", true, latency, props)
 	a.json(w, http.StatusOK, promptEnhanceResponse{Prompt: enriched, Ideas: ideas, Extra: res.Metadata})
 }
 
 func (a *App) PromptRandom(w http.ResponseWriter, r *http.Request) {
+	userID := a.currentUserID(r)
+	if userID == "" {
+		a.error(w, http.StatusUnauthorized, "unauthorized", "missing user context")
+		return
+	}
 	locale := middleware.LocaleFromContext(r.Context())
+	started := time.Now()
 	list, err := a.PromptEnhancer.Random(r.Context(), locale)
-	if err != nil {
+	success := err == nil
+	latency := int(time.Since(started).Milliseconds())
+	if latency < 0 {
+		latency = 0
+	}
+	if !success {
+		a.logUsageEvent(r, userID, "PROMPT_RANDOM", false, latency, map[string]any{"locale": locale})
 		a.error(w, http.StatusInternalServerError, "internal", "failed to fetch prompts")
 		return
 	}
+	provider := ""
+	if len(list) > 0 {
+		provider = list[0].Provider
+	}
+	a.logUsageEvent(r, userID, "PROMPT_RANDOM", true, latency, map[string]any{"locale": locale, "provider": provider})
 	a.json(w, http.StatusOK, map[string]any{"items": list, "generated_at": time.Now()})
+}
+
+func (a *App) logUsageEvent(r *http.Request, userID, event string, success bool, latency int, props map[string]any) {
+	if userID == "" {
+		return
+	}
+	var requestID any
+	if id := middleware.RequestIDFromContext(r.Context()); id != "" {
+		if parsed, err := uuid.Parse(id); err == nil {
+			requestID = parsed
+		}
+	}
+	if props == nil {
+		props = map[string]any{}
+	}
+	payload := jsoncfg.MustMarshal(props)
+	if _, err := a.SQL.Exec(r.Context(), sqlinline.QInsertUsageEvent, userID, requestID, event, success, latency, payload); err != nil {
+		a.Logger.Error().Err(err).Str("event", event).Msg("log usage failed")
+	}
 }

--- a/server/internal/infra/config.go
+++ b/server/internal/infra/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	GeoIPDBPath      string
 	GoogleClientID   string
 	GoogleIssuer     string
+	GeminiAPIKey     string
+	GeminiModel      string
+	GeminiBaseURL    string
 	HTTPReadTimeout  time.Duration
 	HTTPWriteTimeout time.Duration
 	HTTPIdleTimeout  time.Duration
@@ -34,6 +37,9 @@ func LoadConfig() (*Config, error) {
 		GeoIPDBPath:      os.Getenv("GEOIP_DB_PATH"),
 		GoogleClientID:   os.Getenv("GOOGLE_CLIENT_ID"),
 		GoogleIssuer:     getEnv("GOOGLE_ISSUER", "https://accounts.google.com"),
+		GeminiAPIKey:     os.Getenv("GEMINI_API_KEY"),
+		GeminiModel:      getEnv("GEMINI_MODEL", "gemini-1.5-flash"),
+		GeminiBaseURL:    getEnv("GEMINI_BASE_URL", "https://generativelanguage.googleapis.com/v1beta"),
 		HTTPReadTimeout:  time.Second * time.Duration(getEnvInt("HTTP_READ_TIMEOUT_SECONDS", 15)),
 		HTTPWriteTimeout: time.Second * time.Duration(getEnvInt("HTTP_WRITE_TIMEOUT_SECONDS", 30)),
 		HTTPIdleTimeout:  time.Second * time.Duration(getEnvInt("HTTP_IDLE_TIMEOUT_SECONDS", 60)),

--- a/server/internal/middleware/i18n.go
+++ b/server/internal/middleware/i18n.go
@@ -7,9 +7,13 @@ import (
 	"strings"
 )
 
-type localeKey string
+type localeContextKey struct{}
+type countryContextKey struct{}
 
-const LocaleKey localeKey = "locale"
+var (
+	LocaleKey  = localeContextKey{}
+	CountryKey = countryContextKey{}
+)
 
 // CountryLookup resolves ISO country codes for an IP address.
 type CountryLookup func(ip string) (string, error)
@@ -17,31 +21,29 @@ type CountryLookup func(ip string) (string, error)
 func I18N(defaultLocale string, lookup CountryLookup) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			locale := detectLocale(r, defaultLocale, lookup)
+			country := ResolveCountry(r, lookup)
+			locale := detectLocale(r, defaultLocale, country)
 			ctx := context.WithValue(r.Context(), LocaleKey, locale)
+			if country != "" {
+				ctx = context.WithValue(ctx, CountryKey, strings.ToUpper(country))
+			}
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
-func detectLocale(r *http.Request, fallback string, lookup CountryLookup) string {
+func detectLocale(r *http.Request, fallback string, country string) string {
 	if v := r.Header.Get("X-Locale"); v != "" {
 		return normalizeLocale(v)
 	}
 	if v := parseAcceptLanguage(r.Header.Get("Accept-Language")); v != "" {
 		return v
 	}
-	if lookup != nil {
-		if ip := clientIP(r); ip != "" {
-			if country, err := lookup(ip); err == nil {
-				if strings.EqualFold(country, "ID") {
-					return "id"
-				}
-				if country != "" {
-					return "en"
-				}
-			}
-		}
+	if strings.EqualFold(country, "ID") {
+		return "id"
+	}
+	if country != "" {
+		return "en"
 	}
 	if fallback != "" {
 		return fallback
@@ -69,7 +71,11 @@ func normalizeLocale(locale string) string {
 	return "en"
 }
 
-func clientIP(r *http.Request) string {
+// ClientIP returns the best-effort client IP address for the request.
+func ClientIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
 	if xf := r.Header.Get("X-Forwarded-For"); xf != "" {
 		parts := strings.Split(xf, ",")
 		if len(parts) > 0 {
@@ -88,4 +94,58 @@ func LocaleFromContext(ctx context.Context) string {
 		return v
 	}
 	return "en"
+}
+
+// CountryFromContext returns the ISO country code stored in the request context.
+func CountryFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(CountryKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// ResolveCountry resolves a best-effort ISO country code for the given request.
+func ResolveCountry(r *http.Request, lookup CountryLookup) string {
+	if r == nil {
+		return ""
+	}
+	headerHints := []string{"X-Country-Code", "X-IP-Country", "CF-IPCountry", "X-Appengine-Country"}
+	for _, key := range headerHints {
+		if val := strings.TrimSpace(r.Header.Get(key)); val != "" {
+			return strings.ToUpper(val)
+		}
+	}
+	if region := localeRegion(r.Header.Get("X-Locale")); region != "" {
+		return region
+	}
+	if region := localeRegion(r.Header.Get("Accept-Language")); region != "" {
+		return region
+	}
+	if locale := normalizeLocale(r.Header.Get("X-Locale")); locale == "id" {
+		return "ID"
+	}
+	if locale := parseAcceptLanguage(r.Header.Get("Accept-Language")); locale == "id" {
+		return "ID"
+	}
+	if lookup != nil {
+		if ip := ClientIP(r); ip != "" {
+			if country, err := lookup(ip); err == nil && country != "" {
+				return strings.ToUpper(country)
+			}
+		}
+	}
+	return ""
+}
+
+func localeRegion(accept string) string {
+	for _, part := range strings.Split(accept, ",") {
+		token := strings.TrimSpace(strings.Split(part, ";")[0])
+		if token == "" {
+			continue
+		}
+		if idx := strings.IndexAny(token, "-_"); idx > 0 && idx < len(token)-1 {
+			return strings.ToUpper(token[idx+1:])
+		}
+	}
+	return ""
 }

--- a/server/internal/middleware/i18n_test.go
+++ b/server/internal/middleware/i18n_test.go
@@ -16,7 +16,7 @@ func TestDetectLocale(t *testing.T) {
 		name     string
 		setup    func(r *http.Request)
 		fallback string
-		resolver CountryLookup
+		country  string
 		want     string
 	}{
 		{
@@ -24,20 +24,13 @@ func TestDetectLocale(t *testing.T) {
 			setup: func(r *http.Request) {
 				r.Header.Set("X-Locale", "ID")
 			},
-			resolver: func(ip string) (string, error) {
-				t.Fatalf("resolver should not be called")
-				return "", nil
-			},
-			want: "id",
+			country: "US",
+			want:    "id",
 		},
 		{
 			name: "accept-language used",
 			setup: func(r *http.Request) {
 				r.Header.Set("Accept-Language", "en-US,en;q=0.9")
-			},
-			resolver: func(ip string) (string, error) {
-				t.Fatalf("resolver should not be called")
-				return "", nil
 			},
 			want: "en",
 		},
@@ -46,36 +39,17 @@ func TestDetectLocale(t *testing.T) {
 			setup: func(r *http.Request) {
 				r.Header.Set("Accept-Language", "id-ID,en;q=0.8")
 			},
-			resolver: func(ip string) (string, error) {
-				t.Fatalf("resolver should not be called")
-				return "", nil
-			},
 			want: "id",
 		},
 		{
-			name: "geoip returns id",
-			resolver: func(ip string) (string, error) {
-				if ip != "203.0.113.4" {
-					t.Fatalf("unexpected ip: %s", ip)
-				}
-				return "ID", nil
-			},
-			want: "id",
+			name:    "country id overrides",
+			country: "ID",
+			want:    "id",
 		},
 		{
-			name: "geoip returns non-id",
-			resolver: func(ip string) (string, error) {
-				return "US", nil
-			},
-			want: "en",
-		},
-		{
-			name: "geoip error falls back",
-			resolver: func(ip string) (string, error) {
-				return "", assertError("boom")
-			},
-			fallback: "id",
-			want:     "id",
+			name:    "country non-id falls back to en",
+			country: "US",
+			want:    "en",
 		},
 		{
 			name:     "configured fallback",
@@ -91,13 +65,82 @@ func TestDetectLocale(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.setup != nil {
+				tc.setup(req)
+			}
+			got := detectLocale(req, tc.fallback, tc.country)
+			if got != tc.want {
+				t.Fatalf("detectLocale() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveCountry(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(r *http.Request)
+		resolver CountryLookup
+		want     string
+	}{
+		{
+			name: "header precedence",
+			setup: func(r *http.Request) {
+				r.Header.Set("X-Country-Code", "us")
+				r.Header.Set("CF-IPCountry", "id")
+			},
+			want: "US",
+		},
+		{
+			name: "locale region fallback",
+			setup: func(r *http.Request) {
+				r.Header.Set("X-Locale", "en-AU")
+			},
+			want: "AU",
+		},
+		{
+			name: "accept-language region",
+			setup: func(r *http.Request) {
+				r.Header.Set("Accept-Language", "en-GB,en;q=0.9")
+			},
+			want: "GB",
+		},
+		{
+			name: "id locale normalization",
+			setup: func(r *http.Request) {
+				r.Header.Set("Accept-Language", "id;q=0.8")
+			},
+			want: "ID",
+		},
+		{
+			name: "resolver fallback",
+			resolver: func(ip string) (string, error) {
+				if ip != "203.0.113.4" {
+					t.Fatalf("unexpected ip: %s", ip)
+				}
+				return "my", nil
+			},
+			want: "MY",
+		},
+		{
+			name: "resolver error returns empty",
+			resolver: func(ip string) (string, error) {
+				return "", assertError("boom")
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.RemoteAddr = "203.0.113.4:80"
 			if tc.setup != nil {
 				tc.setup(req)
 			}
-			got := detectLocale(req, tc.fallback, tc.resolver)
+			got := ResolveCountry(req, tc.resolver)
 			if got != tc.want {
-				t.Fatalf("detectLocale() = %q, want %q", got, tc.want)
+				t.Fatalf("ResolveCountry() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/server/internal/middleware/requestid.go
+++ b/server/internal/middleware/requestid.go
@@ -7,11 +7,9 @@ import (
 	"github.com/google/uuid"
 )
 
-type contextKey string
+type requestIDContextKey struct{}
 
-const (
-	requestIDKey contextKey = "request_id"
-)
+var requestIDKey = requestIDContextKey{}
 
 func RequestID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/providers/prompt/enhancer.go
+++ b/server/internal/providers/prompt/enhancer.go
@@ -4,21 +4,30 @@ import (
 	"context"
 	"fmt"
 
+	"server/internal/domain/jsoncfg"
+
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
 type EnhanceRequest struct {
-	Title       string
-	ProductType string
-	Locale      string
+	Prompt jsoncfg.PromptJSON
+	Locale string
+}
+
+type EnhanceIdea struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Keywords    []string `json:"keywords"`
 }
 
 type EnhanceResponse struct {
 	Title       string            `json:"title"`
 	Description string            `json:"description"`
 	Keywords    []string          `json:"keywords"`
+	Ideas       []EnhanceIdea     `json:"ideas,omitempty"`
 	Metadata    map[string]string `json:"metadata"`
+	Provider    string            `json:"-"`
 }
 
 type Enhancer interface {
@@ -34,23 +43,37 @@ func NewStaticEnhancer() *StaticEnhancer {
 
 func (s *StaticEnhancer) Enhance(ctx context.Context, req EnhanceRequest) (*EnhanceResponse, error) {
 	c := cases.Title(language.Und)
-	desc := fmt.Sprintf("%s %s dengan gaya premium", c.String(req.ProductType), req.Title)
+	title := req.Prompt.Title
+	if title == "" {
+		title = "Produk UMKM"
+	}
+	product := req.Prompt.ProductType
+	if product == "" {
+		product = "produk"
+	}
+	desc := fmt.Sprintf("%s %s dengan gaya premium", c.String(product), title)
 	res := &EnhanceResponse{
-		Title:       fmt.Sprintf("%s Signature", req.Title),
+		Title:       fmt.Sprintf("%s Signature", title),
 		Description: desc,
 		Keywords:    []string{"kuliner", "fotografi", "umkm"},
 		Metadata: map[string]string{
 			"locale": req.Locale,
 		},
+		Provider: staticProviderName,
 	}
+	res.Ideas = []EnhanceIdea{{
+		Title:       res.Title,
+		Description: res.Description,
+		Keywords:    res.Keywords,
+	}}
 	return res, nil
 }
 
 func (s *StaticEnhancer) Random(ctx context.Context, locale string) ([]EnhanceResponse, error) {
 	items := []EnhanceResponse{
-		{Title: "Nasi Uduk Rempah", Description: "Hidangan sarapan khas Betawi", Keywords: []string{"nasi", "rempah"}, Metadata: map[string]string{"locale": locale}},
-		{Title: "Es Kopi Gula Aren", Description: "Minuman kekinian untuk UMKM", Keywords: []string{"kopi", "gula aren"}, Metadata: map[string]string{"locale": locale}},
-		{Title: "Kue Lapis Legit", Description: "Dessert klasik Nusantara", Keywords: []string{"dessert", "nusantara"}, Metadata: map[string]string{"locale": locale}},
+		{Title: "Nasi Uduk Rempah", Description: "Hidangan sarapan khas Betawi", Keywords: []string{"nasi", "rempah"}, Metadata: map[string]string{"locale": locale}, Provider: staticProviderName},
+		{Title: "Es Kopi Gula Aren", Description: "Minuman kekinian untuk UMKM", Keywords: []string{"kopi", "gula aren"}, Metadata: map[string]string{"locale": locale}, Provider: staticProviderName},
+		{Title: "Kue Lapis Legit", Description: "Dessert klasik Nusantara", Keywords: []string{"dessert", "nusantara"}, Metadata: map[string]string{"locale": locale}, Provider: staticProviderName},
 	}
 	return items, nil
 }

--- a/server/internal/providers/prompt/gemini.go
+++ b/server/internal/providers/prompt/gemini.go
@@ -1,0 +1,364 @@
+package prompt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"server/internal/domain/jsoncfg"
+)
+
+type GeminiOptions struct {
+	APIKey     string
+	Model      string
+	BaseURL    string
+	HTTPClient *http.Client
+	Fallback   Enhancer
+}
+
+type GeminiEnhancer struct {
+	apiKey   string
+	model    string
+	baseURL  string
+	client   *http.Client
+	fallback Enhancer
+}
+
+const (
+	geminiDefaultTimeout = 15 * time.Second
+	geminiProviderName   = "gemini"
+	staticProviderName   = "static"
+)
+
+type geminiRequest struct {
+	Contents         []geminiContent         `json:"contents"`
+	GenerationConfig *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text string `json:"text,omitempty"`
+}
+
+type geminiGenerationConfig struct {
+	Temperature      float64 `json:"temperature,omitempty"`
+	CandidateCount   int     `json:"candidateCount,omitempty"`
+	ResponseMimeType string  `json:"responseMimeType,omitempty"`
+}
+
+type geminiResponse struct {
+	Candidates []struct {
+		Content geminiContent `json:"content"`
+	} `json:"candidates"`
+}
+
+type geminiEnhancePayload struct {
+	Title       string              `json:"title"`
+	Description string              `json:"description"`
+	Keywords    []string            `json:"keywords"`
+	Ideas       []geminiIdeaPayload `json:"ideas"`
+	Metadata    map[string]string   `json:"metadata"`
+}
+
+type geminiIdeaPayload struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Keywords    []string `json:"keywords"`
+}
+
+type geminiRandomPayload struct {
+	Items  []geminiIdeaPayload `json:"items"`
+	Locale string              `json:"locale"`
+}
+
+func NewGeminiEnhancer(opts GeminiOptions) (*GeminiEnhancer, error) {
+	if opts.APIKey == "" {
+		return nil, errors.New("gemini api key is required")
+	}
+	baseURL := strings.TrimRight(opts.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://generativelanguage.googleapis.com/v1beta"
+	}
+	model := strings.TrimSpace(opts.Model)
+	if model == "" {
+		model = "gemini-1.5-flash"
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: geminiDefaultTimeout}
+	}
+	return &GeminiEnhancer{
+		apiKey:   opts.APIKey,
+		model:    model,
+		baseURL:  baseURL,
+		client:   client,
+		fallback: opts.Fallback,
+	}, nil
+}
+
+func (g *GeminiEnhancer) Enhance(ctx context.Context, req EnhanceRequest) (*EnhanceResponse, error) {
+	if g.apiKey == "" {
+		return g.useFallback(ctx, req)
+	}
+	payload := geminiRequest{
+		Contents: []geminiContent{{
+			Role: "user",
+			Parts: []geminiPart{{
+				Text: g.buildEnhancePrompt(req),
+			}},
+		}},
+		GenerationConfig: &geminiGenerationConfig{
+			Temperature:      0.5,
+			CandidateCount:   1,
+			ResponseMimeType: "application/json",
+		},
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+		return g.useFallback(ctx, req)
+	}
+	endpoint := g.endpoint()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &buf)
+	if err != nil {
+		return g.useFallback(ctx, req)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := g.client.Do(httpReq)
+	if err != nil {
+		return g.useFallback(ctx, req)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode >= 300 {
+		return g.useFallback(ctx, req)
+	}
+	var out geminiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return g.useFallback(ctx, req)
+	}
+	text := g.extractText(out)
+	if text == "" {
+		return g.useFallback(ctx, req)
+	}
+	var parsed geminiEnhancePayload
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		return g.useFallback(ctx, req)
+	}
+	response := &EnhanceResponse{
+		Title:       coalesce(parsed.Title, req.Prompt.Title),
+		Description: coalesce(parsed.Description, req.Prompt.Instructions),
+		Keywords:    normalizeKeywords(parsed.Keywords, req.Prompt.ProductType),
+		Metadata:    ensureMetadata(parsed.Metadata, req.Locale),
+		Provider:    geminiProviderName,
+	}
+	if len(parsed.Ideas) > 0 {
+		for _, idea := range parsed.Ideas {
+			response.Ideas = append(response.Ideas, EnhanceIdea{
+				Title:       coalesce(idea.Title, response.Title),
+				Description: coalesce(idea.Description, response.Description),
+				Keywords:    normalizeKeywords(idea.Keywords, req.Prompt.ProductType),
+			})
+		}
+	}
+	if len(response.Ideas) == 0 {
+		response.Ideas = append(response.Ideas, EnhanceIdea{
+			Title:       response.Title,
+			Description: response.Description,
+			Keywords:    response.Keywords,
+		})
+	}
+	return response, nil
+}
+
+func (g *GeminiEnhancer) Random(ctx context.Context, locale string) ([]EnhanceResponse, error) {
+	if g.apiKey == "" {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	payload := geminiRequest{
+		Contents: []geminiContent{{
+			Role: "user",
+			Parts: []geminiPart{{
+				Text: g.buildRandomPrompt(locale),
+			}},
+		}},
+		GenerationConfig: &geminiGenerationConfig{
+			Temperature:      0.7,
+			CandidateCount:   1,
+			ResponseMimeType: "application/json",
+		},
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	endpoint := g.endpoint()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &buf)
+	if err != nil {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := g.client.Do(httpReq)
+	if err != nil {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode >= 300 {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	var out geminiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	text := g.extractText(out)
+	if text == "" {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	var parsed geminiRandomPayload
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	if len(parsed.Items) == 0 {
+		return g.useFallbackRandom(ctx, locale)
+	}
+	var results []EnhanceResponse
+	for _, item := range parsed.Items {
+		meta := ensureMetadata(map[string]string{"locale": parsed.Locale}, locale)
+		results = append(results, EnhanceResponse{
+			Title:       coalesce(item.Title, ""),
+			Description: coalesce(item.Description, ""),
+			Keywords:    normalizeKeywords(item.Keywords, ""),
+			Metadata:    meta,
+			Provider:    geminiProviderName,
+		})
+	}
+	return results, nil
+}
+
+func (g *GeminiEnhancer) endpoint() string {
+	base := strings.TrimRight(g.baseURL, "/")
+	model := url.PathEscape(g.model)
+	return fmt.Sprintf("%s/models/%s:generateContent?key=%s", base, model, url.QueryEscape(g.apiKey))
+}
+
+func (g *GeminiEnhancer) extractText(resp geminiResponse) string {
+	for _, cand := range resp.Candidates {
+		for _, part := range cand.Content.Parts {
+			if strings.TrimSpace(part.Text) != "" {
+				return part.Text
+			}
+		}
+	}
+	return ""
+}
+
+func (g *GeminiEnhancer) useFallback(ctx context.Context, req EnhanceRequest) (*EnhanceResponse, error) {
+	if g.fallback != nil {
+		res, err := g.fallback.Enhance(ctx, req)
+		if res != nil {
+			res.Provider = staticProviderName
+		}
+		return res, err
+	}
+	fallback := NewStaticEnhancer()
+	res, err := fallback.Enhance(ctx, req)
+	if res != nil {
+		res.Provider = staticProviderName
+	}
+	return res, err
+}
+
+func (g *GeminiEnhancer) useFallbackRandom(ctx context.Context, locale string) ([]EnhanceResponse, error) {
+	if g.fallback != nil {
+		items, err := g.fallback.Random(ctx, locale)
+		for i := range items {
+			items[i].Provider = staticProviderName
+		}
+		return items, err
+	}
+	fallback := NewStaticEnhancer()
+	items, err := fallback.Random(ctx, locale)
+	for i := range items {
+		items[i].Provider = staticProviderName
+	}
+	return items, err
+}
+
+func (g *GeminiEnhancer) buildEnhancePrompt(req EnhanceRequest) string {
+	p := req.Prompt
+	locale := req.Locale
+	if locale == "" {
+		locale = p.Extras.Locale
+	}
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "You are a marketing prompt expert helping Indonesian small businesses. Respond strictly with JSON matching this schema: ")
+	sb.WriteString(`{"title":string,"description":string,"keywords":string[],"ideas":[{"title":string,"description":string,"keywords":string[]}],"metadata":{"locale":string}}`)
+	fmt.Fprintf(sb, ". Use locale '%s' for language choices. Input details: title=%q, product_type=%q, style=%q, background=%q, instructions=%q, watermark_enabled=%t. Focus on persuasive yet concise copy.", locale, p.Title, p.ProductType, p.Style, p.Background, p.Instructions, p.Watermark.Enabled)
+	return sb.String()
+}
+
+func (g *GeminiEnhancer) buildRandomPrompt(locale string) string {
+	if locale == "" {
+		locale = "en"
+	}
+	sb := &strings.Builder{}
+	fmt.Fprintf(sb, "Generate three unique product marketing prompt ideas for small businesses. Respond as JSON: {\"items\":[{\"title\":string,\"description\":string,\"keywords\":string[]}],\"locale\":%q}. Use locale '%s' for language.", locale, locale)
+	return sb.String()
+}
+
+func ensureMetadata(meta map[string]string, locale string) map[string]string {
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	if locale != "" {
+		meta["locale"] = locale
+	} else if _, ok := meta["locale"]; !ok {
+		meta["locale"] = jsoncfg.DefaultExtrasLocale
+	}
+	return meta
+}
+
+func normalizeKeywords(keywords []string, fallback string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, kw := range keywords {
+		kw = strings.TrimSpace(kw)
+		if kw == "" {
+			continue
+		}
+		kwLower := strings.ToLower(kw)
+		if _, ok := seen[kwLower]; ok {
+			continue
+		}
+		seen[kwLower] = struct{}{}
+		result = append(result, kw)
+	}
+	if len(result) == 0 && fallback != "" {
+		result = []string{fallback}
+	}
+	return result
+}
+
+func coalesce(values ...string) string {
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+var _ Enhancer = (*GeminiEnhancer)(nil)


### PR DESCRIPTION
## Summary
- add a Gemini-backed prompt enhancer with graceful fallback to the existing static provider for prompt enrichment and seeding
- validate prompt JSON contracts, persist usage metrics for prompt endpoints, and expand usage event types to cover prompt actions
- extend configuration to accept Gemini credentials and update migrations for the broader usage_events constraint

## Testing
- make verify

------
https://chatgpt.com/codex/tasks/task_e_68e0073dc5508333bf2774aa2a55968b